### PR TITLE
OPS-2673 New outputs: bastion hosts instance ids and private ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ module "vpc" {
 | vpc_id | The ID of the VPC |
 | private_subnets | List of IDs of private subnets |
 | public_subnets | List of IDs of public subnets |
-| bastion_asg_name | - |
-| bastion_launch_config_name | - |
+| bastion_asg_name | Autoscaling group name of the bastion host |
+| bastion_launch_config_name | Launch configuration name of the bastion host |
+| bastion_instance_ids | List of EC2 instance ids of deployed bastion hosts |
+| bastion_private_ips | List of private IPs of deployed bastion hosts |
 | bastion_elb_security_group_id | The ID of the SSH security group of the bastion host that can be attached to any other private instance in order to ssh into it. |
 | bastion_security_group_id | The ID of the SSH security group of the bastion host that can be attached to any other private instance in order to ssh into it. |
 | bastion_elb_fqdn | The auto-generated FQDN of the bastion ELB. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,6 @@
+# -------------------------------------------------------------------------------------------------
+# VPC
+# -------------------------------------------------------------------------------------------------
 output "vpc_id" {
   description = "The ID of the VPC"
   value       = "${module.aws_vpc.vpc_id}"
@@ -13,14 +16,39 @@ output "public_subnets" {
   value       = ["${module.aws_vpc.public_subnets}"]
 }
 
+# -------------------------------------------------------------------------------------------------
+# EC2
+# -------------------------------------------------------------------------------------------------
 output "bastion_asg_name" {
-  value = "${aws_autoscaling_group.bastion.name}"
+  description = "Autoscaling group name of the bastion host"
+  value       = "${aws_autoscaling_group.bastion.name}"
 }
 
 output "bastion_launch_config_name" {
-  value = "${aws_launch_configuration.bastion.name}"
+  description = "Launch configuration name of the bastion host"
+  value       = "${aws_launch_configuration.bastion.name}"
 }
 
+data "aws_instances" "bastion" {
+  filter {
+    name   = "tag:Name"
+    values = ["${local.bastion_asg_name}"]
+  }
+}
+
+output "bastion_instance_ids" {
+  description = "List of EC2 instance ids of deployed bastion hosts"
+  value       = ["${data.aws_instances.bastion.ids}"]
+}
+
+output "bastion_private_ips" {
+  description = "List of private IPs of deployed bastion hosts"
+  value       = ["${data.aws_instances.bastion.private_ips}"]
+}
+
+# -------------------------------------------------------------------------------------------------
+# Security Groups
+# -------------------------------------------------------------------------------------------------
 output "bastion_elb_security_group_id" {
   description = "The ID of the SSH security group of the bastion host that can be attached to any other private instance in order to ssh into it."
   value       = "${module.aws_elb.security_group_id}"
@@ -31,6 +59,9 @@ output "bastion_security_group_id" {
   value       = "${aws_security_group.bastion.id}"
 }
 
+# -------------------------------------------------------------------------------------------------
+# DNS names
+# -------------------------------------------------------------------------------------------------
 output "bastion_elb_fqdn" {
   description = "The auto-generated FQDN of the bastion ELB."
   value       = "${module.aws_elb.fqdn}"


### PR DESCRIPTION
# New outputs

This PR adds additional outputs to the module:

| Output | Description |
|--|--|
| bastion_instance_ids | List of EC2 instance ids of deployed bastion hosts |
| bastion_private_ips | List of private IPs of deployed bastion hosts |

## Tagging

After merge, tag with `v0.2.0`