### PR TITLE
OPS-2684 Adding strict code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in the repo.
+*       @devops
+


### PR DESCRIPTION
# Code owners

This PR adds and sets @devops as code owners for this repository

https://blog.github.com/2017-07-06-introducing-code-owners/