### PR TITLE
OPS-2673 Revert outputting instance ids and private ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ module "vpc" {
 | public_subnets | List of IDs of public subnets |
 | bastion_asg_name | Autoscaling group name of the bastion host |
 | bastion_launch_config_name | Launch configuration name of the bastion host |
-| bastion_instance_ids | List of EC2 instance ids of deployed bastion hosts |
-| bastion_private_ips | List of private IPs of deployed bastion hosts |
 | bastion_elb_security_group_id | The ID of the SSH security group of the bastion host that can be attached to any other private instance in order to ssh into it. |
 | bastion_security_group_id | The ID of the SSH security group of the bastion host that can be attached to any other private instance in order to ssh into it. |
 | bastion_elb_fqdn | The auto-generated FQDN of the bastion ELB. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,23 +29,6 @@ output "bastion_launch_config_name" {
   value       = "${aws_launch_configuration.bastion.name}"
 }
 
-data "aws_instances" "bastion" {
-  filter {
-    name   = "tag:Name"
-    values = ["${local.bastion_asg_name}"]
-  }
-}
-
-output "bastion_instance_ids" {
-  description = "List of EC2 instance ids of deployed bastion hosts"
-  value       = ["${data.aws_instances.bastion.ids}"]
-}
-
-output "bastion_private_ips" {
-  description = "List of private IPs of deployed bastion hosts"
-  value       = ["${data.aws_instances.bastion.private_ips}"]
-}
-
 # -------------------------------------------------------------------------------------------------
 # Security Groups
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# Revert outputting instance ids and private ips

This PR reverts the outputs of instance IDs and private IPs of created resources.
Unfortunately the current way of implementation did not work for initial deployments.
Terraform also states that those data should be gathered directly from the state on the project you will be using this module.

## Tagging

After merge this will be tagged with `v0.3.0` due to feature changes.